### PR TITLE
Loop videos and Next.js warnings fix

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -11,7 +11,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
         <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap" rel="stylesheet" />
       </head> 
       <body>

--- a/components/AppBar.jsx
+++ b/components/AppBar.jsx
@@ -7,7 +7,7 @@ import Typography from "@mui/material/Typography";
 export default function OMAppBar() {
     return (
         <Box sx={{ flexGrow: 1 }}>
-            <AppBar position="sticky" variant="outlined">
+            <AppBar position="sticky" elevation={0}>
                 <Toolbar>
                     <Typography
                         variant="h6"

--- a/components/VideoGrid.jsx
+++ b/components/VideoGrid.jsx
@@ -25,8 +25,7 @@ function VideoGrid() {
         <Grid container sx={{ mt: 2, px: 2 }} spacing={3}>
             {filteredVideos.map((data, index) => (
                 <Grid
-                    xs={6}
-                    sx={4}
+                    sm={6}
                     md={4}
                     lg={4}
                     item

--- a/components/VideoGridPlayer.jsx
+++ b/components/VideoGridPlayer.jsx
@@ -28,7 +28,7 @@ function VideoGridPlayer({
                 controls
                 controlsList="nodownload"
                 preload="metadata"
-
+                loop
                 autoPlay
                 muted
             >


### PR DESCRIPTION
Added

- Looping the video when it ends

Fixed warnings

- Invalid prop recieved in crossOrigin
- Invalid prop in Grid (changed sx to sm)
- Variant outlined in Appbar